### PR TITLE
Keyboard/Screen Traps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+termion = "4.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,6 @@
 #![allow(clippy::unusual_byte_groupings)]
 #![allow(clippy::upper_case_acronyms)]
 
-// Comment/Uncomment for disable/enable debug prints
-/*macro_rules! println {
-    ($($rest:tt)*) => {
-        if std::env::var("DEBUG").is_ok() {
-            std::println!($($rest)*);
-        }
-    }
-}*/
-
 mod opcodes;
 mod terminal;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ impl VM<'_> {
                 sr2: Argument::Reg(sr2),
             } => {
                 let res = self.registers[sr1] + self.registers[sr2];
-                println!("ADD reg[{dr}] <- reg[{sr1}] + reg[{sr1}] = {res}");
+                println!("ADD reg[{dr}] <- reg[{sr1}] + reg[{sr2}] = {res}");
                 self.registers[dr] = self.registers[sr1] + self.registers[sr2];
                 self.set_flags(res as i16);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,8 @@ impl VM<'_> {
         self.terminal.clear();
 
         let mut cycle_count = 0; // For debug purposes
-        while self.running && cycle_count < 25 {
+        let cycle_limit = 50;
+        while self.running && cycle_count < cycle_limit {
             // Fetch
             let instruction = self.fetch();
             self.advance_pc();
@@ -353,7 +354,15 @@ impl VM<'_> {
     fn handle_trap_code(&mut self, trap_code: TrapCode) {
         match trap_code {
             TrapCode::Getc => {
-                println!("GETC: Not implemented");
+                println!("TRAP GETC: Press a key and press enter");
+                let b = self.terminal.stdin.next().unwrap().unwrap();
+                dbg!(&b);
+                use termion::event::Key::*;
+                if let Char(ch) = b {
+                    println!("TRAP GETC Read {ch}");
+                    self.registers[0] = u16::try_from(ch).unwrap();
+                    self.set_flags(self.registers[0] as i16);
+                }
             }
             TrapCode::Out => {
                 let ch = self.registers[0] as u8;
@@ -368,7 +377,16 @@ impl VM<'_> {
                 }
             }
             TrapCode::In => {
-                println!("IN: Not implemented");
+                // TODO this is pretty much TRAP_GETC
+                println!("TRAP INPUT: Press a key and press enter");
+                let b = self.terminal.stdin.next().unwrap().unwrap();
+                dbg!(&b);
+                use termion::event::Key::*;
+                if let Char(ch) = b {
+                    println!("TRAP INPUT Read {ch}");
+                    self.registers[0] = u16::try_from(ch).unwrap();
+                    self.set_flags(self.registers[0] as i16);
+                }
             }
             TrapCode::Putsp => {
                 let mut i = self.registers[0] as usize;
@@ -410,7 +428,7 @@ fn join_u8(hi: u8, lo: u8) -> u16 {
 }
 
 fn main() {
-    let data: Vec<u8> = fs::read("2048.obj").expect("Failed to load file");
+    let data: Vec<u8> = fs::read("rogue.obj").expect("Failed to load file");
     let mut vm = VM::new(&data);
     vm.run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ impl VM<'_> {
         self.terminal.clear();
 
         let mut cycle_count = 0; // For debug purposes
-        while self.running && cycle_count < 20 {
+        while self.running {
             // Fetch
             let instruction = self.fetch();
             self.advance_pc();
@@ -382,7 +382,7 @@ fn join_u8(hi: u8, lo: u8) -> u16 {
 }
 
 fn main() {
-    let data: Vec<u8> = fs::read("test.obj").expect("Failed to load file");
+    let data: Vec<u8> = fs::read("2048.obj").expect("Failed to load file");
     let mut vm = VM::new(&data);
     vm.run();
 }

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -98,8 +98,8 @@ impl TryFrom<u16> for Opcode {
         match op {
             0b0001 => {
                 // ADD
-                let dr = instruction & 0b0000_111_000_0_00_000 >> 9;
-                let sr1 = instruction & 0b0000_000_111_0_00_000 >> 6;
+                let dr = (instruction & 0b0000_111_000_0_00_000) >> 9;
+                let sr1 = (instruction & 0b0000_000_111_0_00_000) >> 6;
                 if instruction & (1 << 5) == 0 {
                     // Use sr2 register as 2nd argument
                     let sr2 = instruction & 0b0000_000_000_0_00_111;
@@ -120,8 +120,8 @@ impl TryFrom<u16> for Opcode {
             }
             0b0101 => {
                 // AND , this is the same decode case as ADD
-                let dr = instruction & 0b0000_111_000_0_00_000 >> 9;
-                let sr1 = instruction & 0b0000_000_111_0_00_000 >> 6;
+                let dr = (instruction & 0b0000_111_000_0_00_000u16) >> 9;
+                let sr1 = (instruction & 0b0000_000_111_0_00_000u16) >> 6;
                 if instruction & (1 << 5) == 0 {
                     // Use sr2 register as 2nd argument
                     let sr2 = instruction & 0b0000_000_000_0_00_111;
@@ -151,7 +151,7 @@ impl TryFrom<u16> for Opcode {
             }
             0b1100 => {
                 // JMP/RET
-                let base_r = instruction & 0b0000_000_111_0_00_000 >> 6;
+                let base_r = (instruction & 0b0000_000_111_0_00_000) >> 6;
                 if base_r == 0b111 {
                     Ok(Opcode::RET)
                 } else {

--- a/src/opcodes.rs
+++ b/src/opcodes.rs
@@ -1,3 +1,5 @@
+use crate::TrapCode;
+
 #[derive(Debug)]
 pub enum Argument {
     Reg(usize),
@@ -83,7 +85,7 @@ pub enum Opcode {
     },
     TRAP {
         // Execute Trap
-        trap_vec: u16,
+        trap_code: TrapCode,
     },
     RESERVED, // Unused. Throws an Illegal Opcode Exception.
 }
@@ -230,9 +232,17 @@ impl TryFrom<u16> for Opcode {
                 })
             }
             0b1111 => {
-                Ok(Opcode::TRAP {
-                    trap_vec: instruction & 0b1111_1111, // This is 0-extended, not sign-extended
-                })
+                let trap_code_hex = instruction & 0b1111_1111;
+                let trap_code = match trap_code_hex {
+                    0x20 => TrapCode::Getc,
+                    0x21 => TrapCode::Out,
+                    0x22 => TrapCode::Puts,
+                    0x23 => TrapCode::In,
+                    0x24 => TrapCode::Putsp,
+                    0x25 => TrapCode::Halt,
+                    _ => panic!("Unknown trap code {trap_code_hex} !"),
+                };
+                Ok(Opcode::TRAP { trap_code })
             }
             0b1101 => Ok(Opcode::RESERVED),
             _ => {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -23,4 +23,8 @@ impl Terminal<'_> {
     pub(crate) fn out(&mut self, c: u8) {
         self.stdout.write(&[c]).unwrap();
     }
+
+    pub(crate) fn flush(&mut self) {
+        self.stdout.flush().unwrap()
+    }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,9 +1,10 @@
 use std::io;
 use std::io::{StdinLock, StdoutLock, Write};
+use termion::input::{Keys, TermRead};
 
 pub struct Terminal<'a> {
     stdout: StdoutLock<'a>,
-    stdin: StdinLock<'a>,
+    pub stdin: Keys<StdinLock<'a>>,
 }
 
 impl Terminal<'_> {
@@ -12,7 +13,8 @@ impl Terminal<'_> {
         let mut stdout = stdout.lock();
         let stdin = io::stdin();
         let stdin = stdin.lock();
-        Self { stdout, stdin }
+        let keys = stdin.keys();
+        Self { stdout, stdin: keys }
     }
     pub(crate) fn clear(&mut self) {
         write!(self.stdout, "{}", termion::clear::All).unwrap();

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -7,16 +7,12 @@ pub struct Terminal<'a> {
 }
 
 impl Terminal<'_> {
-
     pub(crate) fn new() -> Self {
         let stdout = io::stdout();
         let mut stdout = stdout.lock();
         let stdin = io::stdin();
         let stdin = stdin.lock();
-        Self {
-            stdout,
-            stdin,
-        }
+        Self { stdout, stdin }
     }
     pub(crate) fn clear(&mut self) {
         write!(self.stdout, "{}", termion::clear::All).unwrap();
@@ -25,5 +21,4 @@ impl Terminal<'_> {
     pub(crate) fn out(&mut self, c: u8) {
         self.stdout.write(&[c]).unwrap();
     }
-
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,29 @@
+use std::io;
+use std::io::{StdinLock, StdoutLock, Write};
+
+pub struct Terminal<'a> {
+    stdout: StdoutLock<'a>,
+    stdin: StdinLock<'a>,
+}
+
+impl Terminal<'_> {
+
+    pub(crate) fn new() -> Self {
+        let stdout = io::stdout();
+        let mut stdout = stdout.lock();
+        let stdin = io::stdin();
+        let stdin = stdin.lock();
+        Self {
+            stdout,
+            stdin,
+        }
+    }
+    pub(crate) fn clear(&mut self) {
+        write!(self.stdout, "{}", termion::clear::All).unwrap();
+    }
+
+    pub(crate) fn out(&mut self, c: u8) {
+        self.stdout.write(&[c]).unwrap();
+    }
+
+}

--- a/test.asm
+++ b/test.asm
@@ -1,0 +1,12 @@
+.ORIG x3000
+
+MAIN
+    AND R2, R2, #0
+    ADD R2, R2, #3
+LOOP
+    ADD R2, R2, #-1
+    BRp LOOP
+    JMP FINI
+FINI
+    HALT
+.END

--- a/test.asm
+++ b/test.asm
@@ -6,7 +6,6 @@ MAIN
 LOOP
     ADD R2, R2, #-1
     BRp LOOP
-    JMP FINI
 FINI
     HALT
 .END


### PR DESCRIPTION
This PR mostly includes the code for handling keyboard traps and showing to the screen via the Termion crate (though this doesn't work that well yet) also:

- Fixes a bug when decoding instructions related to parenthesis in bitmasks/bitshifts
- Fixes the `BR` instruction which I was executing wrongly
- Fixes a bug related to how I was sign-extending values

There's still a lot to fix though.